### PR TITLE
More unnecessary PXBDetId and PXFDetId  includes

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -24,8 +24,6 @@
 
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h"
 
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h" 
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h" 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
@@ -30,7 +30,6 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -50,7 +50,6 @@ New det-id.
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 //#include "Geometry/Surface/interface/Surface.h"
 
 


### PR DESCRIPTION
Found a few more, but these should be the last before submitting a cmssw PR

- RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
- RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
- SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc