### PR TITLE
DPGAnalysis/SiStripTools changes + remove commented code

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTPAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTPAnalyzer.cc
@@ -44,7 +44,6 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -249,33 +248,6 @@ OverlapProblemTPAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
     LogDebug("SimHitDetId") << "List of " << tp->numberOfTrackerHits() << " simhits detid from muon with p = " << tp->p() 
 			    << "and eta = " << tp->eta();
     
-    // commented since with the new TP's I don't know how to loop on PSimHits
-
-    /*
-    for( std::vector<PSimHit>::const_iterator sh = tksimhits.begin(); sh!= tksimhits.end(); ++sh) {
-      
-      // check if the SimHit is Tracker and TEC
-      
-      LogTrace("SimHitDetId") << sh->detUnitId();
-      
-      TECDetId det(sh->detUnitId());
-      if(det.subDetector() == SiStripDetId::TEC) {
-	
-	unsigned int iring = det.ring() - 1;
-	m_simhitytecr[iring]->Fill(sh->entryPoint().y());
-	
-	// check if there is a TrackingRecHit in the same detid and if this is the case fill the histos
-	
-	for(std::vector<DetId>::const_iterator rhdet = rechits.begin(); rhdet!= rechits.end() ; ++rhdet) {
-	  if(det==*rhdet) {
-	    m_assosimhitytecr[iring]->Fill(sh->entryPoint().y());
-	    break;
-	  }
-	}
-	
-      }
-    }
-    */    
   }
   
 }

--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSPositionFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSPositionFilter.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -49,10 +50,12 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "TH1F.h"
 //
@@ -125,6 +128,9 @@ OverlapProblemTSOSPositionFilter::filter(edm::Event& iEvent, const edm::EventSet
   
   Handle<TrajTrackAssociationCollection> ttac;
   iEvent.getByToken(m_ttacollToken,ttac);
+
+  edm::ESHandle<TrackerTopology> tTopo;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo);
   
   for(TrajTrackAssociationCollection::const_iterator pair=ttac->begin();pair!=ttac->end();++pair) {
     
@@ -143,10 +149,9 @@ OverlapProblemTSOSPositionFilter::filter(edm::Event& iEvent, const edm::EventSet
 
       if(hit->geographicalId().det() != DetId::Tracker) continue;
       
-      TECDetId det(hit->geographicalId());
-      if(det.subDetector() != SiStripDetId::TEC) continue;
-      
-      if(det.ring() != 6) continue;
+      if(hit->geographicalId().subdetId() != StripSubdetector::TEC) continue;
+
+      if(tTopo->tecRing(hit->geographicalId()) != 6) continue;
 
       if(tsos.localPosition().y() < 6.) continue; 
 


### PR DESCRIPTION
In OverlapProblemTPAnalyzer.cc, I just removed the commented part related to SiStrip DetId and the include. 