### PR TITLE
Remove specific DetIds in SiStripDetSummary

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripDelay.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDelay.h
@@ -82,9 +82,9 @@ class SiStripDelay
   }
 
   /// Prints the average value of the delays for all layers and wheels in the SiStripTracker
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /// Prints the delays for all the detIds
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* tTopo) const;
 
  private:
 

--- a/CalibFormats/SiStripObjects/interface/SiStripDetCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetCabling.h
@@ -50,9 +50,9 @@ class SiStripDetCabling
   void print( std::stringstream& ) const;
 
   /** The printSummary method outputs the number of connected/detected/undetected modules for each layer of each subdetector.*/
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /** The printDebug method returns all the connected/detected/undetected modules.*/
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
   // Methods to get the number of connected, detected and undetected modules for each layer of each subdetector.
   uint32_t connectedNumber(const std::string & subDet, const uint16_t layer) const { return detNumber(subDet, layer, 0); }

--- a/CalibFormats/SiStripObjects/interface/SiStripGain.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripGain.h
@@ -37,6 +37,8 @@
 #include <vector>
 #include <memory>
 
+class TrackerTopology;
+
 class SiStripGain
 {
  public:
@@ -101,8 +103,8 @@ class SiStripGain
     return normVector_[index];
   }
 
-  void printDebug(std::stringstream& ss) const;
-  void printSummary(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
  private:
 

--- a/CalibFormats/SiStripObjects/src/SiStripDelay.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDelay.cc
@@ -114,7 +114,7 @@ void SiStripDelay::clear()
   delays_.clear();
 }
 
-void SiStripDelay::printDebug(std::stringstream & ss) const
+void SiStripDelay::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const
 {
   boost::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
   for( ; it != delays_.end(); ++it ) {
@@ -122,9 +122,9 @@ void SiStripDelay::printDebug(std::stringstream & ss) const
   }
 }
 
-void SiStripDelay::printSummary(std::stringstream& ss) const
+void SiStripDelay::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
-  SiStripDetSummary summaryDelays;
+  SiStripDetSummary summaryDelays{trackerTopo};
   boost::unordered_map<uint32_t, double>::const_iterator it = delays_.begin();
   for( ; it != delays_.end(); ++it ) {
     summaryDelays.add(it->first, it->second);

--- a/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
@@ -358,7 +358,7 @@ void SiStripDetCabling::print( std::stringstream& ss ) const {
      << "Number of connections: " << total << std::endl;
 }
 
-void SiStripDetCabling::printSummary(std::stringstream& ss) const {
+void SiStripDetCabling::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const {
   for( int connectionType = 0; connectionType < 3; ++connectionType ) {
     if( connectionType == 0 ) ss << "Connected modules:" << std::endl;
     else if( connectionType == 1 ) ss << "Detected modules:" << std::endl;
@@ -389,6 +389,6 @@ void SiStripDetCabling::printSummary(std::stringstream& ss) const {
   }
 }
 
-void SiStripDetCabling::printDebug(std::stringstream& ss) const {
+void SiStripDetCabling::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {
   print(ss);
 }

--- a/CalibFormats/SiStripObjects/src/SiStripGain.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripGain.cc
@@ -117,7 +117,7 @@ const SiStripApvGain::Range SiStripGain::getRange(const uint32_t& DetId, const u
   return apvgainVector_[index]->getRange(DetId);
 }
 
-void SiStripGain::printDebug(std::stringstream & ss) const
+void SiStripGain::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const
 {
   std::vector<unsigned int> detIds;
   getDetIds(detIds);
@@ -136,9 +136,9 @@ void SiStripGain::printDebug(std::stringstream & ss) const
   }
 }
 
-void SiStripGain::printSummary(std::stringstream& ss) const
+void SiStripGain::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
-  SiStripDetSummary summaryGain;
+  SiStripDetSummary summaryGain{trackerTopo};
 
   std::vector<unsigned int> detIds;
   getDetIds(detIds);

--- a/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
@@ -22,6 +22,7 @@
 #include "CondFormats/Common/interface/TimeConversions.h"
 //#include "DataFormats/Provenance/interface/Timestamp.h"
 
+class TrackerTopology;
 
 #include <fstream>
 #include <iostream>
@@ -46,7 +47,7 @@ class SiStripDetVOffBuilder
   /** Default constructor. */
   SiStripDetVOffBuilder(const edm::ParameterSet&,const edm::ActivityRegistry&);
   /** Build the SiStripDetVOff object for transfer. */
-  void BuildDetVOffObj();
+  void BuildDetVOffObj(const TrackerTopology* trackerTopo);
   /** Return modules Off vector of objects. */
   std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > getModulesVOff() {
     reduction(deltaTmin_, maxIOVlength_);

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
@@ -72,10 +72,13 @@ void SiStripDetVOffHandler::analyze(const edm::Event& evt, const edm::EventSetup
   }
   condDbSession.transaction().commit();
 
+  edm::ESHandle<TrackerTopology> tTopo;
+  evtSetup.get<TrackerTopologyRcd>().get(tTopo);
+
   // build the object!
   newPayloads.clear();
   modHVBuilder->setLastSiStripDetVOff( lastPayload.get(), lastIov );
-  modHVBuilder->BuildDetVOffObj();
+  modHVBuilder->BuildDetVOffObj(tTopo.product());
   newPayloads = modHVBuilder->getModulesVOff();
   edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
       << "Finished building " << newPayloads.size() << " new payloads.";

--- a/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
@@ -1,6 +1,7 @@
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
 #include "boost/foreach.hpp"
 #include <sys/stat.h>
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 // constructor
 SiStripDetVOffBuilder::SiStripDetVOffBuilder(const edm::ParameterSet& pset, const edm::ActivityRegistry&) : 
@@ -87,7 +88,7 @@ void SiStripDetVOffBuilder::printPar(std::stringstream& ss, const std::vector<in
   }
 }
 
-void SiStripDetVOffBuilder::BuildDetVOffObj()
+void SiStripDetVOffBuilder::BuildDetVOffObj(const TrackerTopology* trackerTopo)
 {
   // vectors for storing output from DB or text file
   TimesAndValues timesAndValues;

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
@@ -48,9 +48,11 @@ void DummyCondObjPrinter<TObject,TRecord>::analyze(const edm::Event& e, const ed
 
   edm::ESHandle<TObject> esobj;
   es.get<TRecord>().get( esobj );
+  edm::ESHandle<TrackerTopology> tTopo;
+  es.get<TrackerTopologyRcd>().get(tTopo);
   std::stringstream sSummary, sDebug;
-  esobj->printSummary(sSummary);
-  esobj->printDebug(sDebug);
+  esobj->printSummary(sSummary, tTopo.product());
+  esobj->printDebug(sDebug, tTopo.product());
 
   //  edm::LogInfo("DummyCondObjPrinter") << "\nPrintSummary \n" << sSummary.str()  << std::endl;
   //  edm::LogWarning("DummyCondObjPrinter") << "\nPrintDebug \n" << sDebug.str()  << std::endl;

--- a/CondFormats/SiStripObjects/BuildFile.xml
+++ b/CondFormats/SiStripObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
+<use   name="DataFormats/TrackerCommon"/>
 <use   name="DataFormats/SiStripCommon"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DataFormats/FEDRawData"/>

--- a/CondFormats/SiStripObjects/interface/SiStripApvGain.h
+++ b/CondFormats/SiStripObjects/interface/SiStripApvGain.h
@@ -8,6 +8,9 @@
 #include<iostream>
 #include<boost/cstdint.hpp>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+class TrackerTopology;
+
 /**
  * Stores the information of the gain for each apv using four vectors <br>
  * A vector<unsigned int> (v_detids) stores the detId. <br>
@@ -78,8 +81,8 @@ class SiStripApvGain {
 #endif
 
 
-  void printDebug(std::stringstream & ss) const;
-  void printSummary(std::stringstream & ss) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
 
  private:
 

--- a/CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h
@@ -37,9 +37,9 @@ public:
   float getBackPlaneCorrection (const uint32_t&) const;
 
   /// Prints BackPlaneCorrections for all detIds.
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /// Prints the mean value of the BackPlaneCorrection divided by subdetector, layer and mono/stereo.
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
 private:
   std::map<unsigned int,float> m_BPC; 

--- a/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
@@ -9,6 +9,8 @@
 #include<boost/cstdint.hpp>
 #include "DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h"
 
+class TrackerTopology;
+
 /**
  * Holds the list of bad components. <br>
  * The bad components can be filled with two put methods, that receive a DetId and
@@ -68,8 +70,8 @@ class SiStripBadStrip {
   const Range getRange(const uint32_t detID) const;
   Range getRangeByPos(unsigned short pos) const;
   void getDetIds(std::vector<uint32_t>& DetIds_) const;
-  void printSummary(std::stringstream & ss) const;
-  void printDebug(std::stringstream & ss) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
 
   ContainerIterator getDataVectorBegin()    const {return v_badstrips.begin();}
   ContainerIterator getDataVectorEnd()      const {return v_badstrips.end();}

--- a/CondFormats/SiStripObjects/interface/SiStripBaseDelay.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBaseDelay.h
@@ -71,9 +71,9 @@ class SiStripBaseDelay
   }
 
   /// Prints the average value of the delays for all layers and wheels in the SiStripTracker
-  void printSummary(std::stringstream & ss) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
   /// Prints the delays for all the detIds
-  void printDebug(std::stringstream & ss) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
 
  private:
 

--- a/CondFormats/SiStripObjects/interface/SiStripConfObject.h
+++ b/CondFormats/SiStripObjects/interface/SiStripConfObject.h
@@ -12,6 +12,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+class TrackerTopology;
+
 /**
  * Author M. De Mattia - 16/11/2009
  *
@@ -82,9 +84,9 @@ class SiStripConfObject
   }
 
   /// Prints the full list of parameters
-  void printSummary(std::stringstream & ss) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
   /// Prints the full list of parameters
-  void printDebug(std::stringstream & ss) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
 
   typedef std::map<std::string, std::string> parMap;
 

--- a/CondFormats/SiStripObjects/interface/SiStripDetSummary.h
+++ b/CondFormats/SiStripObjects/interface/SiStripDetSummary.h
@@ -1,11 +1,8 @@
 #ifndef SiStripDetSummary_h
 #define SiStripDetSummary_h
 
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h" 
-#include "DataFormats/SiStripDetId/interface/TECDetId.h" 
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h" 
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h" 
 #include "DataFormats/DetId/interface/DetId.h"
+class TrackerTopology;
 
 #include <sstream>
 #include <map>
@@ -31,7 +28,7 @@
 class SiStripDetSummary
 {
 public:
-  SiStripDetSummary() : computeMean_(true)
+  explicit SiStripDetSummary(const TrackerTopology* tTopo) : computeMean_(true), trackerTopo_(tTopo)
   {
     // Initialize valueMap_ with zeros
     // WARNING: this initialization is strongly connected with how the map is filled in the add method
@@ -52,9 +49,9 @@ public:
   }
 
   /// Used to compute the mean value of the value variable divided by subdetector, layer and mono/stereo
-  void add(const DetId & detid, const float & value);
+  void add(DetId detid, float value);
   /// Used to compute the number of entries divided by subdetector, layer and mono/stereo
-  inline void add(const DetId & detid)
+  inline void add(DetId detid)
   {
     computeMean_ = false;
     add( detid, 0 );
@@ -81,6 +78,8 @@ protected:
   // Maps to store the value and the counts
   std::map<unsigned int, Values> valueMap_;
   bool computeMean_;
+private:
+  const TrackerTopology* trackerTopo_;
 };
 
 #endif

--- a/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
+++ b/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
@@ -45,7 +45,7 @@ class SiStripDetVOff
   static const unsigned int eightBitMask = 0xFFFFFFFF;
   static const short bitShift = 2;
 
-  explicit SiStripDetVOff() {}
+  SiStripDetVOff() {}
   ~SiStripDetVOff() {}
   SiStripDetVOff( const SiStripDetVOff & toCopy ) { toCopy.getVoff(v_Voff); }
 

--- a/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
+++ b/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
@@ -9,6 +9,8 @@
 #include<boost/cstdint.hpp>
 #include <string>
 
+class TrackerTopology;
+
 /**
  * This class stores the information if the HV or LV of a detId were off. <br>
  * Internally it uses two bits to store the information about HV and LV. It saves a uint32_t
@@ -43,7 +45,7 @@ class SiStripDetVOff
   static const unsigned int eightBitMask = 0xFFFFFFFF;
   static const short bitShift = 2;
 
-  SiStripDetVOff() {}
+  explicit SiStripDetVOff() {}
   ~SiStripDetVOff() {}
   SiStripDetVOff( const SiStripDetVOff & toCopy ) { toCopy.getVoff(v_Voff); }
 
@@ -67,8 +69,8 @@ class SiStripDetVOff
 
   bool IsModuleLVOff(const uint32_t DetID) const;
 
-  void printDebug(std::stringstream & ss) const;
-  void printSummary(std::stringstream & ss) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology*) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology*) const;
 
   /// Returns the total number of modules with LV off
   int getLVoffCounts() const;

--- a/CondFormats/SiStripObjects/interface/SiStripFedCabling.h
+++ b/CondFormats/SiStripObjects/interface/SiStripFedCabling.h
@@ -13,11 +13,9 @@
 #define SISTRIPCABLING_USING_NEW_STRUCTURE
 #define SISTRIPCABLING_USING_NEW_INTERFACE
 
+class TrackerTopology;
 
 class SiStripFedCabling;
-
-/** Debug info for SiStripFedCabling class. */
-std::ostream& operator<< ( std::ostream&, const SiStripFedCabling& );
 
 /** 
     \class SiStripFedCabling 
@@ -91,21 +89,21 @@ class SiStripFedCabling {
   void buildFedCabling( ConnsConstIterRange connections );
   
   /** Prints all connection information for this FED cabling object. */
-  void printDebug( std::stringstream& ) const;
+  void printDebug( std::stringstream&, const TrackerTopology* trackerTopo ) const;
 
   /// LEFT FOR COMPATIBILITY. SHOULD BE REPLACED BY PRINTDEBUG
-  void print( std::stringstream& ss ) const {
-    printDebug(ss);
+  void print( std::stringstream& ss, const TrackerTopology* trackerTopo ) const {
+    printDebug(ss, trackerTopo);
   }
   
   /** Prints terse information for this FED cabling object. */
   void terse( std::stringstream& ) const;
   
   /** Prints summary information for this FED cabling object. */
-  void printSummary( std::stringstream& ) const;
+  void printSummary( std::stringstream&, const TrackerTopology* trackerTopo ) const;
   /// LEFT FOR COMPATIBILITY. SHOULD BE REPLACED BY PRINTSUMMARY
-  void summary( std::stringstream& ss ) const {
-    printSummary(ss);
+  void summary( std::stringstream& ss, const TrackerTopology* trackerTopo ) const {
+    printSummary(ss, trackerTopo);
   }
 
   /// Builds range of iterators from pair of offsets

--- a/CondFormats/SiStripObjects/interface/SiStripLatency.h
+++ b/CondFormats/SiStripObjects/interface/SiStripLatency.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <sstream>
 
+class TrackerTopology;
+
 #define READMODEMASK 8
 
 /**
@@ -114,9 +116,9 @@ class SiStripLatency
   uint16_t singleMode() const;
 
   /// Prints the number of ranges as well as the value of singleLatency and singleMode
-  void printSummary(std::stringstream & ss) const;
+  void printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
   /// Prints the full list of all ranges and corresponding values of latency and mode
-  void printDebug(std::stringstream & ss) const;
+  void printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const;
 
   struct OrderByDetIdAndApv
   {

--- a/CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h
+++ b/CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h
@@ -36,9 +36,9 @@ public:
   float getLorentzAngle (const uint32_t&) const;
 
   /// Prints LorentzAngles for all detIds.
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /// Prints the mean value of the LorentzAngle divided by subdetector, layer and mono/stereo.
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
 private:
   std::map<unsigned int,float> m_LA; 

--- a/CondFormats/SiStripObjects/interface/SiStripNoises.h
+++ b/CondFormats/SiStripObjects/interface/SiStripNoises.h
@@ -11,6 +11,8 @@
 #include<cassert>
 #include<cstring>
 
+class TrackerTopology;
+
 /**
  * Stores the noise value for all the strips. <br>
  * The values are encoded from a vector<uint16_t> to a vector<unsigned char> <br>
@@ -80,8 +82,8 @@ class SiStripNoises
   void    allNoises (std::vector<float> & noises, const Range& range) const;
   void    setData(float noise_, InputVector& vped);
 
-  void printDebug(std::stringstream& ss) const;
-  void printSummary(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
   std::vector<ratioData> operator / (const SiStripNoises& d) ;
 

--- a/CondFormats/SiStripObjects/interface/SiStripPedestals.h
+++ b/CondFormats/SiStripObjects/interface/SiStripPedestals.h
@@ -72,9 +72,9 @@ public:
   void  allPeds  (std::vector<int> & pefs,  const Range& range) const;
 
   /// Prints mean pedestal value divided for subdet, layer and mono/stereo.
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /// Prints all pedestals.
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
  private:
 

--- a/CondFormats/SiStripObjects/interface/SiStripThreshold.h
+++ b/CondFormats/SiStripObjects/interface/SiStripThreshold.h
@@ -10,6 +10,8 @@
 #include "DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h"
 #include <sstream>
 
+class TrackerTopology;
+
 /**
  * Holds the thresholds:<br>
  * - High threshold <br>
@@ -129,9 +131,9 @@ class SiStripThreshold {
   void  allThresholds(std::vector<float> &lowThs, std::vector<float> &highThs, const Range& range)  const; 
 
   /// Prints mean, rms, min and max threshold values for each DetId.
-  void printSummary(std::stringstream& ss) const;
+  void printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
   /// Prints all the thresholds for all DetIds. 
-  void printDebug(std::stringstream& ss) const;
+  void printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const;
 
  private:
   

--- a/CondFormats/SiStripObjects/src/SiStripApvGain.cc
+++ b/CondFormats/SiStripObjects/src/SiStripApvGain.cc
@@ -82,7 +82,7 @@ float SiStripApvGain::getApvGain(const uint16_t& apv, const Range& range) {
 #endif
 
 
-void SiStripApvGain::printDebug(std::stringstream & ss) const
+void SiStripApvGain::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const
 {
   std::vector<unsigned int>::const_iterator detid = v_detids.begin();
   ss << "Number of detids " << v_detids.size() << std::endl;
@@ -99,9 +99,9 @@ void SiStripApvGain::printDebug(std::stringstream & ss) const
   }
 }
 
-void SiStripApvGain::printSummary(std::stringstream & ss) const
+void SiStripApvGain::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
-  SiStripDetSummary summaryGain;
+  SiStripDetSummary summaryGain{trackerTopo};
 
   std::vector<uint32_t>::const_iterator detid = v_detids.begin();
   for( ; detid != v_detids.end(); ++detid ) {

--- a/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
@@ -1,6 +1,6 @@
 #include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
 
 bool SiStripBackPlaneCorrection::putBackPlaneCorrection(const uint32_t& detid, float value){
   std::map<unsigned int,float>::const_iterator id=m_BPC.find(detid);
@@ -20,7 +20,7 @@ float SiStripBackPlaneCorrection::getBackPlaneCorrection(const uint32_t& detid) 
   return 0;
 }
 
-void SiStripBackPlaneCorrection::printDebug(std::stringstream& ss) const
+void SiStripBackPlaneCorrection::printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
   std::map<unsigned int,float> detid_la = getBackPlaneCorrections();
   std::map<unsigned int,float>::const_iterator it;
@@ -28,19 +28,17 @@ void SiStripBackPlaneCorrection::printDebug(std::stringstream& ss) const
   ss << "SiStripBackPlaneCorrectionReader:" << std::endl;
   ss << "detid \t Geometry \t Back Plane Corrections" << std::endl;
   for( it=detid_la.begin(); it!=detid_la.end(); ++it ) {
-    SiStripDetId SSdetId(it->first);
-    unsigned int moduleGeometry = SSdetId.moduleGeometry();
-    ss << it->first << "\t" << moduleGeometry << "\t" << it->second << std::endl;
+    ss << it->first << "\t" << trackerTopo->moduleGeometry(it->first) << "\t" << it->second << std::endl;
     ++count;
   }
 }
 
-void SiStripBackPlaneCorrection::printSummary(std::stringstream& ss) const
+void SiStripBackPlaneCorrection::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
   std::map<unsigned int,float> detid_la = getBackPlaneCorrections();
   std::map<unsigned int,float>::const_iterator it;
 
-  SiStripDetSummary summary;
+  SiStripDetSummary summary{trackerTopo};
 
   for( it=detid_la.begin(); it!=detid_la.end(); ++it ) {
     DetId detid(it->first);

--- a/CondFormats/SiStripObjects/src/SiStripBadStrip.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBadStrip.cc
@@ -56,9 +56,9 @@ void SiStripBadStrip::getDetIds(std::vector<uint32_t>& DetIds_) const {
   }
 }
 
-void SiStripBadStrip::printSummary(std::stringstream & ss) const {
-  SiStripDetSummary summaryBadModules;
-  SiStripDetSummary summaryBadStrips;
+void SiStripBadStrip::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const {
+  SiStripDetSummary summaryBadModules{trackerTopo};
+  SiStripDetSummary summaryBadStrips{trackerTopo};
 
   // Loop on the vector<DetRegistry> and take the bad modules and bad strips
   Registry::const_iterator it = indexes.begin();
@@ -72,7 +72,7 @@ void SiStripBadStrip::printSummary(std::stringstream & ss) const {
   summaryBadStrips.print(ss, false);
 }
 
-void SiStripBadStrip::printDebug(std::stringstream & ss) const {
+void SiStripBadStrip::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const {
   ss << "Printing all bad strips for all DetIds" << std::endl;
   // Loop on the vector<DetRegistry> and take the bad modules and bad strips
   Registry::const_iterator it = indexes.begin();

--- a/CondFormats/SiStripObjects/src/SiStripBaseDelay.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBaseDelay.cc
@@ -48,10 +48,10 @@ void SiStripBaseDelay::detIds(std::vector<uint32_t> & detIdVector) const
   }
 }
 
-void SiStripBaseDelay::printSummary(std::stringstream & ss) const
+void SiStripBaseDelay::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
   ss << "Total number of delays = " << delays_.size() << std::endl;
-  SiStripDetSummary summaryDelays;
+  SiStripDetSummary summaryDelays{trackerTopo};
   delayConstIt it = delays_.begin();
   for( ; it != delays_.end(); ++it ) {
     summaryDelays.add(it->detId, makeDelay(it->coarseDelay, it->fineDelay));
@@ -60,9 +60,9 @@ void SiStripBaseDelay::printSummary(std::stringstream & ss) const
   summaryDelays.print(ss);
 }
 
-void SiStripBaseDelay::printDebug(std::stringstream & ss) const
+void SiStripBaseDelay::printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
-  printSummary(ss);
+  printSummary(ss, trackerTopo);
   delayConstIt it = delays_.begin();
   ss << std::endl << "All pedestal values:" << std::endl;
   for( ; it != delays_.end(); ++it ) {

--- a/CondFormats/SiStripObjects/src/SiStripConfObject.cc
+++ b/CondFormats/SiStripObjects/src/SiStripConfObject.cc
@@ -110,7 +110,7 @@ std::vector<std::string> SiStripConfObject::get<std::vector<std::string> >( cons
 }
 
 
-void SiStripConfObject::printSummary(std::stringstream & ss) const
+void SiStripConfObject::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
   parMap::const_iterator it = parameters.begin();
   for( ; it != parameters.end(); ++it ) {
@@ -118,7 +118,7 @@ void SiStripConfObject::printSummary(std::stringstream & ss) const
   }
 }
 
-void SiStripConfObject::printDebug(std::stringstream & ss) const
+void SiStripConfObject::printDebug(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
-  printSummary(ss);
+  printSummary(ss, trackerTopo);
 }

--- a/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
+++ b/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
@@ -1,6 +1,8 @@
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 
-void SiStripDetSummary::add(const DetId & detid, const float & value)
+void SiStripDetSummary::add(DetId detid, float value)
 {
   int layer = 0;
   int stereo = 0;
@@ -8,40 +10,28 @@ void SiStripDetSummary::add(const DetId & detid, const float & value)
 
   // Using the operator[] if the element does not exist it is created with the default value. That is 0 for integral types.
   switch (detid.subdetId()) {
-  case StripSubdetector::TIB:
-    {
-      TIBDetId theTIBDetId(detid.rawId());
-      layer = theTIBDetId.layer();
-      stereo = theTIBDetId.stereo();
+    case StripSubdetector::TIB:
+      layer = trackerTopo_->tibLayer(detid);
+      stereo = trackerTopo_->tibStereo(detid);
       detNum = 1000;
       break;
-    }
-  case StripSubdetector::TOB:
-    {
-      TOBDetId theTOBDetId(detid.rawId());
-      layer = theTOBDetId.layer();
-      stereo = theTOBDetId.stereo();
+    case StripSubdetector::TOB:
+      layer = trackerTopo_->tobLayer(detid);
+      stereo = trackerTopo_->tobStereo(detid);
       detNum = 2000;
       break;
-    }
-  case StripSubdetector::TEC:
-    {
-      TECDetId theTECDetId(detid.rawId());
+    case StripSubdetector::TEC:
       // is this module in TEC+ or TEC-?
-      layer = theTECDetId.wheel();
-      stereo = theTECDetId.stereo();
+      layer = trackerTopo_->tecWheel(detid);
+      stereo = trackerTopo_->tecStereo(detid);
       detNum = 3000;
       break;
-    }
-  case StripSubdetector::TID:
-    {
-      TIDDetId theTIDDetId(detid.rawId());
+    case StripSubdetector::TID:
       // is this module in TID+ or TID-?
-      layer = theTIDDetId.wheel();
-      stereo = theTIDDetId.stereo();
+      layer = trackerTopo_->tidWheel(detid);
+      stereo = trackerTopo_->tidStereo(detid);
       detNum = 4000;
       break;
-    }
   }
   detNum += layer*10 + stereo;
   // string name( detector + boost::lexical_cast<string>(layer) + boost::lexical_cast<string>(stereo) );

--- a/CondFormats/SiStripObjects/src/SiStripDetVOff.cc
+++ b/CondFormats/SiStripObjects/src/SiStripDetVOff.cc
@@ -95,7 +95,7 @@ bool SiStripDetVOff::IsModuleHVOff(const uint32_t DetId) const
   return false;
 }
 
-void SiStripDetVOff::printDebug(std::stringstream & ss) const
+void SiStripDetVOff::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const
 {
   std::vector<uint32_t> detIds;
   getDetIds(detIds);
@@ -112,44 +112,24 @@ void SiStripDetVOff::printDebug(std::stringstream & ss) const
 
 int SiStripDetVOff::getLVoffCounts() const
 {
-  SiStripDetSummary summaryLV;
   std::vector<uint32_t> detIds;
   getDetIds(detIds);
-  constVoffIterator it = detIds.begin();
-  for( ; it!=detIds.end(); ++it ) {
-    if( IsModuleLVOff(*it)) summaryLV.add(*it);
-  }
-  int totalCount = 0;
-  std::map<unsigned int, SiStripDetSummary::Values> counts = summaryLV.getCounts();
-  std::map<unsigned int, SiStripDetSummary::Values>::const_iterator mapIt = counts.begin();
-  for( ; mapIt != counts.end(); ++mapIt ) {
-    totalCount += mapIt->second.count;
-  }
-  return totalCount;
+  return std::count_if(std::begin(detIds), std::end(detIds),
+      std::bind(&SiStripDetVOff::IsModuleLVOff, this, std::placeholders::_1));
 }
 
 int SiStripDetVOff::getHVoffCounts() const
 {
-  SiStripDetSummary summaryHV;
   std::vector<uint32_t> detIds;
   getDetIds(detIds);
-  constVoffIterator it = detIds.begin();
-  for( ; it!=detIds.end(); ++it ) {
-    if( IsModuleHVOff(*it)) summaryHV.add(*it);
-  }
-  int totalCount = 0;
-  std::map<unsigned int, SiStripDetSummary::Values> counts = summaryHV.getCounts();
-  std::map<unsigned int, SiStripDetSummary::Values>::const_iterator mapIt = counts.begin();
-  for( ; mapIt != counts.end(); ++mapIt ) {
-    totalCount += mapIt->second.count;
-  }
-  return totalCount;
+  return std::count_if(std::begin(detIds), std::end(detIds),
+      std::bind(&SiStripDetVOff::IsModuleHVOff, this, std::placeholders::_1));
 }
 
-void SiStripDetVOff::printSummary(std::stringstream & ss) const
+void SiStripDetVOff::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
-  SiStripDetSummary summaryHV;
-  SiStripDetSummary summaryLV;
+  SiStripDetSummary summaryHV{trackerTopo};
+  SiStripDetSummary summaryLV{trackerTopo};
   std::vector<uint32_t> detIds;
   getDetIds(detIds);
   constVoffIterator it = detIds.begin();

--- a/CondFormats/SiStripObjects/src/SiStripFedCabling.cc
+++ b/CondFormats/SiStripObjects/src/SiStripFedCabling.cc
@@ -214,7 +214,7 @@ FedChannelConnection SiStripFedCabling::fedConnection( uint16_t fed_id,
 
 // -----------------------------------------------------------------------------
 // 
-void SiStripFedCabling::printDebug( std::stringstream& ss ) const {
+void SiStripFedCabling::printDebug( std::stringstream& ss, const TrackerTopology* /*trackerTopo*/ ) const {
 
   uint16_t total = 0;
   uint16_t nfeds = 0;
@@ -342,7 +342,7 @@ void SiStripFedCabling::terse( std::stringstream& ss ) const {
 
 // -----------------------------------------------------------------------------
 //
-void SiStripFedCabling::printSummary( std::stringstream& ss ) const {
+void SiStripFedCabling::printSummary( std::stringstream& ss, const TrackerTopology* /*trackerTopo*/ ) const {
 
   ss << "[SiStripFedCabling::" << __func__ << "]";
   
@@ -422,13 +422,4 @@ void SiStripFedCabling::printSummary( std::stringstream& ss ) const {
      << " " << percent
      << "% of FED channels are connected"  << std::endl;
   
-}
-
-// -----------------------------------------------------------------------------
-//
-std::ostream& operator<< ( std::ostream& os, const SiStripFedCabling& cabling ) {
-  std::stringstream ss;
-  cabling.print(ss);
-  os << ss.str();
-  return os;
 }

--- a/CondFormats/SiStripObjects/src/SiStripLatency.cc
+++ b/CondFormats/SiStripObjects/src/SiStripLatency.cc
@@ -170,7 +170,7 @@ std::vector<SiStripLatency::Latency> SiStripLatency::allUniqueLatencyAndModes()
   return latencyCopy;
 }
 
-void SiStripLatency::printSummary(std::stringstream & ss) const
+void SiStripLatency::printSummary(std::stringstream & ss, const TrackerTopology* trackerTopo) const
 {
   ss << std::endl;
   if(singleReadOutMode()==1){
@@ -195,11 +195,11 @@ void SiStripLatency::printSummary(std::stringstream & ss) const
     }
   }
   ss << "Total number of ranges = " << latencies_.size() << std::endl;
-  printDebug(ss);
+  printDebug(ss, trackerTopo);
 }
 
 
-void SiStripLatency::printDebug(std::stringstream & ss) const
+void SiStripLatency::printDebug(std::stringstream & ss, const TrackerTopology* /*trackerTopo*/) const
 {
   ss << "List of all the latencies and modes for the " << latencies_.size() << " ranges in the object:" << std::endl;
   for( latConstIt it = latencies_.begin(); it != latencies_.end(); ++it ) {

--- a/CondFormats/SiStripObjects/src/SiStripLorentzAngle.cc
+++ b/CondFormats/SiStripObjects/src/SiStripLorentzAngle.cc
@@ -20,7 +20,7 @@ float SiStripLorentzAngle::getLorentzAngle(const uint32_t& detid) const  {
   return 0;
 }
 
-void SiStripLorentzAngle::printDebug(std::stringstream& ss) const
+void SiStripLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const
 {
   std::map<unsigned int,float> detid_la = getLorentzAngles();
   std::map<unsigned int,float>::const_iterator it;
@@ -33,12 +33,12 @@ void SiStripLorentzAngle::printDebug(std::stringstream& ss) const
   }
 }
 
-void SiStripLorentzAngle::printSummary(std::stringstream& ss) const
+void SiStripLorentzAngle::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
   std::map<unsigned int,float> detid_la = getLorentzAngles();
   std::map<unsigned int,float>::const_iterator it;
 
-  SiStripDetSummary summary;
+  SiStripDetSummary summary{trackerTopo};
 
   for( it=detid_la.begin(); it!=detid_la.end(); ++it ) {
     DetId detid(it->first);

--- a/CondFormats/SiStripObjects/src/SiStripNoises.cc
+++ b/CondFormats/SiStripObjects/src/SiStripNoises.cc
@@ -188,7 +188,7 @@ std::string SiStripNoises::print_short_as_binary(const short ch) const
 }
 */
 
-void SiStripNoises::printDebug(std::stringstream& ss) const{
+void SiStripNoises::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const{
   RegistryIterator rit=getRegistryVectorBegin(), erit=getRegistryVectorEnd();
   uint16_t Nstrips;
   std::vector<float> vstripnoise;
@@ -215,9 +215,9 @@ void SiStripNoises::printDebug(std::stringstream& ss) const{
   }
 }
 
-void SiStripNoises::printSummary(std::stringstream& ss) const{
+void SiStripNoises::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const{
 
-  SiStripDetSummary summary;
+  SiStripDetSummary summary{trackerTopo};
 
   std::stringstream tempss;
 

--- a/CondFormats/SiStripObjects/src/SiStripPedestals.cc
+++ b/CondFormats/SiStripObjects/src/SiStripPedestals.cc
@@ -161,11 +161,11 @@ SiStripPedestals::allPeds  (std::vector<int>   & peds,  const Range& range) cons
     }
 }
 
-void SiStripPedestals::printSummary(std::stringstream& ss) const
+void SiStripPedestals::printSummary(std::stringstream& ss, const TrackerTopology* trackerTopo) const
 {
   std::vector<uint32_t> detid;
   getDetIds(detid);
-  SiStripDetSummary summary;
+  SiStripDetSummary summary{trackerTopo};
   for( size_t id = 0; id < detid.size(); ++id ) {
     SiStripPedestals::Range range = getRange(detid[id]);
     for( int it=0; it < (range.second-range.first)*8/10; ++it ){
@@ -177,7 +177,7 @@ void SiStripPedestals::printSummary(std::stringstream& ss) const
 }
 
 
-void SiStripPedestals::printDebug(std::stringstream& ss) const
+void SiStripPedestals::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const
 {
   std::vector<uint32_t> detid;
   getDetIds(detid);

--- a/CondFormats/SiStripObjects/src/SiStripThreshold.cc
+++ b/CondFormats/SiStripObjects/src/SiStripThreshold.cc
@@ -98,7 +98,7 @@ void SiStripThreshold::allThresholds(std::vector<float> &lowThs, std::vector<flo
     }
 }    
 
-void SiStripThreshold::printDebug(std::stringstream& ss) const{
+void SiStripThreshold::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const{
   RegistryIterator rit=getRegistryVectorBegin(), erit=getRegistryVectorEnd();
   ContainerIterator it,eit;
   for(;rit!=erit;++rit){
@@ -112,7 +112,7 @@ void SiStripThreshold::printDebug(std::stringstream& ss) const{
   }
 }
 
-void SiStripThreshold::printSummary(std::stringstream& ss) const{
+void SiStripThreshold::printSummary(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const{
   RegistryIterator rit=getRegistryVectorBegin(), erit=getRegistryVectorEnd();
   ContainerIterator it,eit,itp;
   float meanLth, meanHth, meanCth; //mean value 

--- a/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.cc
@@ -59,11 +59,13 @@ void SiStripFedCablingBuilder::beginRun( const edm::Run& run,
     return;
   }
   
+  edm::ESHandle<TrackerTopology> tTopo;
+  setup.get<TrackerTopologyRcd>().get(tTopo);
   {
     std::stringstream ss;
     ss << "[SiStripFedCablingBuilder::" << __func__ << "]"
        << " VERBOSE DEBUG" << std::endl;
-    fed->print( ss );
+    fed->print(ss, tTopo.product());
     ss << std::endl;
     if ( printFecCabling_ && fec.isValid() ) { fec->print( ss ); }
     ss << std::endl;
@@ -87,7 +89,7 @@ void SiStripFedCablingBuilder::beginRun( const edm::Run& run,
     std::stringstream ss;
     ss << "[SiStripFedCablingBuilder::" << __func__ << "]"
        << " SUMMARY DEBUG" << std::endl;
-    fed->summary( ss );
+    fed->summary(ss, tTopo.product());
     ss << std::endl;
     edm::LogVerbatim("SiStripFedCablingBuilder") << ss.str();
   }

--- a/CondTools/SiStrip/plugins/SiStripFedCablingReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingReader.cc
@@ -77,7 +77,11 @@ void SiStripFedCablingReader::beginRun( const edm::Run& run,
     std::stringstream ss;
     ss << "[SiStripFedCablingReader::" << __func__ << "]"
        << " VERBOSE DEBUG" << std::endl;
-    if(FedRcdfound)fed->print( ss );
+    if(FedRcdfound) {
+      edm::ESHandle<TrackerTopology> tTopo;
+      setup.get<TrackerTopologyRcd>().get(tTopo);
+      fed->print(ss, tTopo.product());
+    }
     ss << std::endl;
     if ( FecRcdfound && printFecCabling_ && fec.isValid() ) { fec->print( ss ); }
     ss << std::endl;
@@ -101,7 +105,9 @@ void SiStripFedCablingReader::beginRun( const edm::Run& run,
     std::stringstream ss;
     ss << "[SiStripFedCablingReader::" << __func__ << "]"
        << " SUMMARY DEBUG" << std::endl;
-    fed->summary( ss );
+    edm::ESHandle<TrackerTopology> tTopo;
+    setup.get<TrackerTopologyRcd>().get(tTopo);
+    fed->summary(ss, tTopo.product());
     ss << std::endl;
     edm::LogVerbatim("SiStripFedCablingReader") << ss.str();
   }

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
@@ -158,8 +158,11 @@ APVCyclePhaseProducerFromL1TS::beginRun(const edm::Run& iRun, const edm::EventSe
     edm::ESHandle<SiStripConfObject> confObj;
     iSetup.get<SiStripConfObjectRcd>().get(m_rcdLabel,confObj);
 
+    edm::ESHandle<TrackerTopology> tTopo;
+    iSetup.get<TrackerTopologyRcd>().get(tTopo);
+
     std::stringstream summary;
-    confObj->printDebug(summary);
+    confObj->printDebug(summary, tTopo.product());
     LogDebug("SiStripConfObjectSummary") << summary.str();
 
     _defpartnames = confObj->get<std::vector<std::string> >("defaultPartitionNames");

--- a/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
@@ -24,6 +24,8 @@ class CommissioningHistosUsingDb : public virtual CommissioningHistograms {
 
   virtual ~CommissioningHistosUsingDb();
 
+  virtual void configure( const edm::ParameterSet&, const edm::EventSetup& );
+
   void uploadToConfigDb();
   
   bool doUploadAnal() const;

--- a/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
@@ -49,7 +49,7 @@ CommissioningHistosUsingDb::CommissioningHistosUsingDb( SiStripConfigDb* const d
   std::stringstream sss;
   sss << "[CommissioningHistosUsingDb::" << __func__ << "]"
       << " Summary of FED cabling:" << std::endl;
-  cabling_->summary(sss);
+  cabling_->summary(sss, nullptr); // FIXME FIXME FIXME this will crash
   edm::LogVerbatim(mlDqmClient_) << sss.str();
   
 }

--- a/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
@@ -1,3 +1,5 @@
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
 #include "CalibFormats/SiStripObjects/interface/NumberOfDevices.h"
@@ -28,30 +30,6 @@ CommissioningHistosUsingDb::CommissioningHistosUsingDb( SiStripConfigDb* const d
   LogTrace(mlDqmClient_) 
     << "[" << __PRETTY_FUNCTION__ << "]"
     << " Constructing object...";
-  
-  // Build FEC cabling object from connections found in DB
-  SiStripFecCabling fec_cabling;
-  if ( runType_ == sistrip::FAST_CABLING ) {
-    SiStripFedCablingBuilderFromDb::buildFecCablingFromDevices( db_, fec_cabling );
-  } else {
-    SiStripFedCablingBuilderFromDb::buildFecCabling( db_, fec_cabling );
-  }
-  
-  // Build FED cabling from FEC cabling
-  cabling_ = new SiStripFedCabling();
-  SiStripFedCablingBuilderFromDb::getFedCabling( fec_cabling, *cabling_ );
-  std::stringstream ss;
-  ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
-     << " Terse print out of FED cabling:" << std::endl;
-  cabling_->terse(ss);
-  LogTrace(mlDqmClient_) << ss.str();
-  
-  std::stringstream sss;
-  sss << "[CommissioningHistosUsingDb::" << __func__ << "]"
-      << " Summary of FED cabling:" << std::endl;
-  cabling_->summary(sss, nullptr); // FIXME FIXME FIXME this will crash
-  edm::LogVerbatim(mlDqmClient_) << sss.str();
-  
 }
 
 // -----------------------------------------------------------------------------
@@ -77,6 +55,41 @@ CommissioningHistosUsingDb::~CommissioningHistosUsingDb() {
   LogTrace(mlDqmClient_) 
     << "[" << __PRETTY_FUNCTION__ << "]"
     << " Destructing object...";
+}
+
+void CommissioningHistosUsingDb::configure( const edm::ParameterSet&, const edm::EventSetup& setup )
+{
+  if ( !db_ ) {
+    edm::LogError(mlDqmClient_)
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Cannot configure...";
+  } else {
+    // Build FEC cabling object from connections found in DB
+    SiStripFecCabling fec_cabling;
+    if ( runType_ == sistrip::FAST_CABLING ) {
+      SiStripFedCablingBuilderFromDb::buildFecCablingFromDevices( db_, fec_cabling );
+    } else {
+      SiStripFedCablingBuilderFromDb::buildFecCabling( db_, fec_cabling );
+    }
+
+    // Build FED cabling from FEC cabling
+    cabling_ = new SiStripFedCabling();
+    SiStripFedCablingBuilderFromDb::getFedCabling( fec_cabling, *cabling_ );
+    std::stringstream ss;
+    ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+       << " Terse print out of FED cabling:" << std::endl;
+    cabling_->terse(ss);
+    LogTrace(mlDqmClient_) << ss.str();
+
+    edm::ESHandle<TrackerTopology> tTopo;
+    setup.get<TrackerTopologyRcd>().get(tTopo);
+    std::stringstream sss;
+    sss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+        << " Summary of FED cabling:" << std::endl;
+    cabling_->summary(sss, tTopo.product());
+    edm::LogVerbatim(mlDqmClient_) << sss.str();
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
@@ -51,6 +51,7 @@ FineDelayHistosUsingDb::~FineDelayHistosUsingDb() {
 /** */
 void FineDelayHistosUsingDb::configure( const edm::ParameterSet& pset, 
 					const edm::EventSetup& setup ) {
+  CommissioningHistosUsingDb::configure(pset, setup);
   // get geometry
   edm::ESHandle<TrackerGeometry> estracker;
   setup.get<TrackerDigiGeometryRecord>().get(estracker);

--- a/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
@@ -381,6 +381,7 @@ void LatencyHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
 
 void LatencyHistosUsingDb::configure( const edm::ParameterSet& pset, const edm::EventSetup& es)
 {
+  CommissioningHistosUsingDb::configure(pset, es);
   perPartition_ = this->pset().getParameter<bool>("OptimizePerPartition");
 }
 

--- a/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMService.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMService.cc
@@ -30,7 +30,7 @@ void SiStripBadComponentsDQMService::getMetaDataString(std::stringstream& ss)
 {
   ss << "Run " << getRunNumber() << std::endl;
   readBadComponents();
-  obj_->printSummary(ss);
+  obj_->printSummary(ss, nullptr); // FIXME FIXME FIXME will crash
 }
 
 bool SiStripBadComponentsDQMService::checkForCompatibility(std::string ss)

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.cc
@@ -154,7 +154,9 @@ namespace sistrip {
 	std::stringstream sss;
 	sss << "[sistrip::RawToDigiModule::" << __func__ << "]"
 	    << " Summary of FED cabling:" << std::endl;
-	cabling_->summary(sss);
+	edm::ESHandle<TrackerTopology> tTopo;
+	setup.get<TrackerTopologyRcd>().get(tTopo);
+	cabling_->summary(sss, tTopo.product());
 	LogTrace("SiStripRawToDigi") << sss.str();
       }
       cacheId_ = cache_id;

--- a/OnlineDB/SiStripESSources/src/SiStripCondObjBuilderFromDb.cc
+++ b/OnlineDB/SiStripESSources/src/SiStripCondObjBuilderFromDb.cc
@@ -831,8 +831,8 @@ void SiStripCondObjBuilderFromDb::buildFECRelatedObjects( SiStripConfigDb* const
   latency_->compress();
   std::stringstream ss;
   // latency debug output
-  latency_->printSummary(ss);
-  latency_->printDebug(ss);
+  latency_->printSummary(ss, tTopo);
+  latency_->printDebug(ss, tTopo);
   std::cout << ss.str() << std::endl;
 }
 

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
@@ -10,6 +10,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 class StripTopology;
 


### PR DESCRIPTION
Not finished yet, but pushing already to collect some feedback.

The last two commits are the remaining open issues (I put `nullptr` to make it compile).
For `CommissioningHistosUsingDb`, I think we can move the things from the constructor to the `configure` method (which is called later and gets an `edm::EventSetup`), would be nice to be able to test that...
For the `SiStripBadComponentsDQMService` I would propose to use @alesaggio 's legacy solution for now (I have a work-in-progress branch from last year to restructure this and related classes not to be Services any more, I can promise to update and submit that soon and properly solve the issue then - in the end this is run from an `edm::EDAnalyzer`, if memory serves, so this should be solvable).
The `SiStripDetVOffBuilder` change should ideally also be tested.